### PR TITLE
Fix Typo in `tag_parser.go`

### DIFF
--- a/sszgen/generator/tag_parser.go
+++ b/sszgen/generator/tag_parser.go
@@ -139,7 +139,7 @@ func extractSSZDimensions(tag string) ([]*SSZDimension, error) {
 		switch szi {
 		case "?", "":
 			if mxi == "?" || mxi == "" {
-				return nil, fmt.Errorf("no numeric ssz-size or ssz-max tag for value at dimesion %d", i)
+				return nil, fmt.Errorf("no numeric ssz-size or ssz-max tag for value at dimension %d", i)
 			}
 			m, err := strconv.Atoi(mxi)
 			if err != nil {


### PR DESCRIPTION
# Pull Request Title
Fix Typo in `tag_parser.go`

## Description
This pull request addresses a minor typo in the `tag_parser.go` file, improving code readability and maintaining professionalism in error messages.

### Changes Made:
- **File Modified:** `sszgen/generator/tag_parser.go`
- **Summary of Changes:**
  - Corrected "dimesion" to "dimension" in the error message on line 139.

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Updated documentation or comments for clarity.
- [x] Confirmed no impact on code functionality.

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Typo fix in error message)

## Additional Notes
This fix ensures that error messages are clear and free from typographical errors, contributing to the overall quality of the codebase.

---

**Allow edits by maintainers:** [x]
